### PR TITLE
Simplify templates, add PR template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug---data.md
+++ b/.github/ISSUE_TEMPLATE/bug---data.md
@@ -1,7 +1,7 @@
 ---
 name: Bug - Data
 about: Report a bug related to data processing, quality, or integrity
-title: "[BUG - Data]"
+title: ""
 type: Bug
 assignees: ''
 
@@ -9,63 +9,27 @@ assignees: ''
 
 ## Bug Description
 
-> Describe the data issue...
+> What is the issue, where does it occur, screenshots...
 
 ---
 
-## Data Source
+### Steps to Reproduce
 
-> List affected data sources...
+> Modify the steps to fit your case
 
----
-
-## Type of Data Issue
-What type of data issue is this?
-Select all that apply:
-
-- [ ] Data Quality
-- [ ] Data Integrity
-- [ ] Data Processing
-- [ ] Data Loading
-- [ ] Data Validation
-- [ ] Data Transformation
-- [ ] Data Export
-- [ ] Other
+1. Export dataset GM0911 from ETLocal
+2. Go to ETSource
+3. Observe issue with value XYZ
 
 ---
 
-## Expected Data
+## Expected interaction
+What is the expected behaviour?
 
-> Expected data format, values, etc...
-
----
-
-## Actual Data
-
-> Actual data format, values, etc...
-> Sample data showing the issue...
+> What would you think should be happening, describe or alter a screenshot
 
 ---
 
-## Steps to Reproduce
+### Proposed solutions
 
-> Add or modify steps as needed.
-
-1. Load data from '...'
-2. Process with '...'
-3. Observe incorrect data
-
-
----
-
-## Impact
-Describe how this affects downstream processes or outputs.
-
-> Describe the impact...
-
----
-
-## Additional Context
-Add any other context about the problem here.
-
-> Any additional information...
+> What do you think is causing the issue, or what do you think might solve it?

--- a/.github/ISSUE_TEMPLATE/bug---dev.md
+++ b/.github/ISSUE_TEMPLATE/bug---dev.md
@@ -1,50 +1,19 @@
 ---
 name: Bug - Dev
 about: Report a bug related to development issues
-title: "[BUG - Dev]"
-labels: bug
+title: ""
+type: Bug
 assignees: ''
 
 ---
 
 ## Bug Description
 
-> Describe the dev issue...
+> What is the issue, where does it occur, screenshots...
 
 ---
 
-## Where is it happening
-
-> List affected environments, servers, or services...
-
----
-
-## Type of Issue
-What type of dev issue is this?
-Select all that apply:
-
-- [ ] User Experience
-- [ ] Unintuitive design
-- [ ] Calculation
-- [ ] API
-- [ ] Tests
-- [ ] Other
-
----
-
-## Expected Behaviour
-
-> Expected dev behaviour...
-
----
-
-## Current Behaviour
-
-> Current dev behaviour
-
----
-
-## Steps to Reproduce
+### Steps to Reproduce
 
 > Modify the steps to fit your case
 
@@ -54,13 +23,13 @@ Select all that apply:
 
 ---
 
-## Impact
+## Expected interaction
+What is the expected behaviour?
 
-> Describe the impact...
+> What would you think should be happening, describe or alter a screenshot
 
 ---
 
-## Additional Context
-Add any other context about the problem here.
+### Proposed solutions
 
-> Any additional information...
+> What do you think is causing the issue, or what do you think might solve it?

--- a/.github/ISSUE_TEMPLATE/bug---interface.md
+++ b/.github/ISSUE_TEMPLATE/bug---interface.md
@@ -1,16 +1,15 @@
 ---
 name: Bug - Interface
 about: Report a bug related to an interface issue
-title: "[BUG - Interface]"
+title: ""
 type: Bug
 assignees: ''
 
 ---
 
 ## Bug Description
-A clear and concise description of what the interface bug is.
 
-> Describe the data issue...
+> What is the issue, where does it occur, screenshots...
 
 ---
 
@@ -22,16 +21,13 @@ steps, please attach multiple screenshots
 
 ---
 
-## Type of Interface Issue
-What type of interface issue is this?
-Select all that apply:
+### Steps to Reproduce
 
-- [ ] Spelling Mistake
-- [ ] Broken links
-- [ ] Interface Quality
-- [ ] Interface Bug / Visual bug
-- [ ] Unexpected Behaviour
-- [ ] Other
+> Modify the steps to fit your case
+
+1. Set input X to Y
+2. Go to node Z
+3. Observe issue
 
 ---
 
@@ -42,19 +38,6 @@ What is the expected behaviour?
 
 ---
 
-## Steps to Reproduce
-Steps to reproduce the issue if not already clear from the screenshots.
+### Proposed solutions
 
-Example:
-1. Start scenario '...'
-2. Open chart '...'
-3. Cannot distinguish two colors, dutch translation is missing.
-
-> Add or modify steps as needed.
-
----
-
-## Additional Context
-Add any other context about the problem here.
-
-> Any additional information...
+> What do you think is causing the issue, or what do you think might solve it?

--- a/.github/ISSUE_TEMPLATE/bug---mod.md
+++ b/.github/ISSUE_TEMPLATE/bug---mod.md
@@ -1,49 +1,19 @@
 ---
 name: Bug - Mod
 about: Report a bug related to modelling issues
-title: "[BUG - Mod]"
-labels: bug
+title: ""
+type: Bug
 assignees: ''
 
 ---
 
 ## Bug Description
 
-> Describe the modelling issue...
+> What is the issue, where does it occur, screenshots...
 
 ---
 
-## Where is it happening
-
-> List affected environments, servers, or services...
-
----
-
-## Type of Issue
-What type of modelling issue is this?
-Select all that apply:
-
-- [ ] Calculation
-- [ ] Graph
-- [ ] Input
-- [ ] Chart
-- [ ] Other
-
----
-
-## Expected Behaviour
-
-> Expected modelling behaviour...
-
----
-
-## Current Behaviour
-
-> Current modelling behaviour
-
----
-
-## Steps to Reproduce
+### Steps to Reproduce
 
 > Modify the steps to fit your case
 
@@ -51,15 +21,12 @@ Select all that apply:
 2. Go to node Z
 3. Observe issue
 
----
+## Expected Behaviour
 
-## Impact
-
-> Describe the impact...
+> Expected behaviour...
 
 ---
 
-## Additional Context
-Add any other context about the problem here.
+## Proposed solutions
 
-> Any additional information...
+> What do you think is causing the issue, or what do you think might solve it?

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -1,7 +1,7 @@
 ---
 name: Enhancement
 about: Suggest an improvement to existing functionality
-title: "[Enhancement] - "
+title: ""
 type: Enhancement
 assignees: ''
 
@@ -9,33 +9,7 @@ assignees: ''
 
 ## Description
 
-> **Describe the enhancement here...**
-
----
-
-### Enhancement Type
-What type of enhancement is this?
-
-- [ ] Performance Improvement
-- [ ] User Experience
-- [ ] Code Quality
-- [ ] Documentation
-- [ ] Error Handling
-- [ ] Accessibility
-- [ ] Security
-- [ ] Maintainability
-- [ ] Other
-
----
-
-### Priority
-How important is this enhancement?
-
-- [ ] Nice to have
-- [ ] Low
-- [ ] Medium
-- [ ] High
-- [ ] Critical
+> **Describe the enhancement here, what is the motivation...**
 
 ---
 
@@ -51,29 +25,9 @@ How important is this enhancement?
 
 ---
 
-
-## Motivation
-
-> **Explain the motivation and benefits...**
-
----
-
-### Affected Components
-
-> **List affected components...**
-
----
-
 ## Implementation Ideas
 
 > **Describe potential implementation approaches...**
-
----
-
-### Considerations
-
-> **Describe any potential breaking changes or other considerations...**
-
 
 ---
 
@@ -82,9 +36,3 @@ How important is this enhancement?
 > **How would you measure the success of this enhancement?**
 
 - [ ]
-
----
-
-### Additional Context
-
-> **Any additional information...**

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+## Description
+
+Please include a summary of the changes and the related issue.
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Enhancement
+- [ ] Documentation
+
+## Checklist
+
+- [ ] I have tested these changes
+- [ ] I have updated documentation as needed
+- [ ] I have tagged the relevant people for review
+
+## Related Issues
+
+Closes #


### PR DESCRIPTION
I'm opening this draft PR for changes to the templates - I do think it's a good idea to talk through their purpose together as a team though.

In general I'm not sure it's really necessary to have different templates for the types of bugs after all, in general this structure seems to be pretty universal for 'bugs':

```
- Description
  - How to reproduce (current behaviour)
- Expected behaviour
- Proposed solutions
```

For an enhancement it's slightly different as you can see in the changes.

I also included a basic draft PR template - I think it would be worth discussing that one too.